### PR TITLE
Empty topic counts as empty list

### DIFF
--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -381,7 +381,7 @@ bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Reque
   rosbag::Bag bag;
 
   // Write each selected topic's queue to bag file
-  if (req.topics.size())
+  if (req.topics.size() && req.topics.at(0).size())
   {
     for (std::string& topic : req.topics)
     {


### PR DESCRIPTION
tab-complete on the commandline always inserts a list with an empty string.

I had to inspect the code to see why my simple launch file was not working when calling the trigger service from the commandline. Since empty topics cannot be recorded anyway I see no downsides to this.

I don't have a strong opinion about it though, if one thinks it clutters the code too much feel free to leave it out.