### PR TITLE
change NO_DATA to NO_DATA_MESSAGE to avoid conflict with boost

### DIFF
--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -428,7 +428,7 @@ bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Reque
   if (!bag.isOpen())
   {
     res.success = false;
-    res.message = res.NO_DATA;
+    res.message = res.NO_DATA_MESSAGE;
     return true;
   }
 

--- a/rosbag_snapshot/test/test_snapshot.py
+++ b/rosbag_snapshot/test/test_snapshot.py
@@ -90,7 +90,7 @@ class TestRosbagSnapshot(unittest.TestCase):
         filename = tempfile.mktemp()
         res = self.trigger(filename=filename, topics=topics)
         self.assertFalse(res.success)
-        self.assertEqual(res.message, TriggerSnapshotResponse.NO_DATA)
+        self.assertEqual(res.message, TriggerSnapshotResponse.NO_DATA_MESSAGE)
         self.assertFalse(os.path.isfile(filename))
 
     def _assert_record_success(self, data):

--- a/rosbag_snapshot_msgs/srv/TriggerSnapshot.srv
+++ b/rosbag_snapshot_msgs/srv/TriggerSnapshot.srv
@@ -14,5 +14,5 @@ time stop_time    # Latest timestamp for a message to be included in written bag
 
 bool success    # True if snapshot successfully written to disk
 
-string NO_DATA=no messages buffered on selected topics
+string NO_DATA_MESSAGE=no messages buffered on selected topics
 string message  # Error description if failed


### PR DESCRIPTION
This PR fixes the conflict of NO_DATA with netdb.h which is used by boost. 

Fixes #11 