### PR TITLE
Add count limit option

### DIFF
--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -66,18 +66,24 @@ struct ROSBAG_DECL SnapshotterTopicOptions
   static const ros::Duration NO_DURATION_LIMIT;
   // When the value of memory_limit_, do not trunctate the buffer no matter how much memory it consumes (DANGROUS)
   static const int32_t NO_MEMORY_LIMIT;
+  // When the value of count_limit_, do not trunctate the buffer no matter how many message it consumes
+  static const int32_t NO_COUNT_LIMIT;
   // When the value of duration_limit_, inherit the limit from the node's configured default
   static const ros::Duration INHERIT_DURATION_LIMIT;
   // When the value of memory_limit_, inherit the limit from the node's configured default
   static const int32_t INHERIT_MEMORY_LIMIT;
+  // When the value of count_limit_, inherit the limit from the node's configured default
+  static const int32_t INHERIT_COUNT_LIMIT;
 
   // Maximum difference in time from newest and oldest message in buffer before older messages are removed
   ros::Duration duration_limit_;
   // Maximum memory usage of the buffer before older messages are removed
   int32_t memory_limit_;
+  // Maximum number of message in the buffer before older messages are removed
+  int32_t count_limit_;
 
   SnapshotterTopicOptions(ros::Duration duration_limit = INHERIT_DURATION_LIMIT,
-                         int32_t memory_limit = INHERIT_MEMORY_LIMIT);
+                          int32_t memory_limit = INHERIT_MEMORY_LIMIT, int32_t count_limit = INHERIT_COUNT_LIMIT);
 };
 
 /* Configuration for the Snapshotter node. Contains default limits for memory and duration
@@ -89,6 +95,8 @@ struct ROSBAG_DECL SnapshotterOptions
   ros::Duration default_duration_limit_;
   // Memory limit to use for a topic's buffer if one is not specified
   int32_t default_memory_limit_;
+  // Count limit to use for a topic's buffer if one is not specified
+  int32_t default_count_limit_;
   // Period between publishing topic status messages. If <= ros::Duration(0), don't publish status
   ros::Duration status_period_;
   // Flag if all topics should be recorded
@@ -99,12 +107,13 @@ struct ROSBAG_DECL SnapshotterOptions
   topics_t topics_;
 
   SnapshotterOptions(ros::Duration default_duration_limit = ros::Duration(30), int32_t default_memory_limit = -1,
-                    ros::Duration status_period = ros::Duration(1));
+                     int32_t default_count_limit = -1, ros::Duration status_period = ros::Duration(1));
 
   // Add a new topic to the configuration, returns false if the topic was already present
   bool addTopic(std::string const& topic,
                 ros::Duration duration_limit = SnapshotterTopicOptions::INHERIT_DURATION_LIMIT,
-                int32_t memory_limit = SnapshotterTopicOptions::INHERIT_MEMORY_LIMIT);
+                int32_t memory_limit = SnapshotterTopicOptions::INHERIT_MEMORY_LIMIT,
+                int32_t count_limit = SnapshotterTopicOptions::INHERIT_COUNT_LIMIT);
 };
 
 /* Stores a buffered message of an ambiguous type and it's associated metadata (time of arrival, connection data),

--- a/rosbag_snapshot/test/snapshot.test
+++ b/rosbag_snapshot/test/snapshot.test
@@ -3,6 +3,7 @@
     <rosparam>
         default_duration_limit: 1  # Maximum time difference between newest and oldest message, seconds, overrides -d flag
         default_memory_limit: 0.1  # Maximum memory used by messages in each topic's buffer, MB, override -s flag
+        default_count_limit: 1000  # Maximum number of messages in each topic's buffer, override -c flag
         topics:
             - test1                # Inherit defaults
             - test2:               # Override duration limit, inherit memory limit
@@ -10,11 +11,15 @@
             - test3:               # Override both limits
                 duration: -1       # Negative means no duration limit
                 memory: 0.00
+            - test4:
+                duration: -1       # Negative means no duration limit
+                count: 2
     </rosparam>
   </node>
   <!-- A bunch of fixed frequency publishers, each 64bits to make size calculations easy -->
   <node name="test1pub" pkg="rostopic" type="rostopic" args="pub /test1 std_msgs/Time '{data:{ secs: 0, nsecs: 0}}' -r2"/>
   <node name="test2pub" pkg="rostopic" type="rostopic" args="pub /test2 std_msgs/Int64 'data: 1337' -r12"/>
   <node name="test3pub" pkg="rostopic" type="rostopic" args="pub /test3 std_msgs/Float64 'data: 42.00' -r25" />
+  <node name="test4pub" pkg="rostopic" type="rostopic" args="pub /test4 std_msgs/Float64 'data: 42.00' -r25" />
   <test test-name="snapshot_test" pkg="rosbag_snapshot" type="test_snapshot.py"/>
 </launch>


### PR DESCRIPTION
Add the option to specify a maximum number of messages per topic.

Use case:
There are some topics where only the last message is interesting. Examples are state topics where only the current state is relevant. In my case I also have a point cloud topic that I want to include, but only the last point cloud is relevant (to save bandwith and disk space).

Resolves #17
