### PR TITLE
Make the subscription queue size configurable

### DIFF
--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -205,7 +205,6 @@ public:
   int run();
 
 private:
-  // Subscribe queue size for each topic 
   SnapshotterOptions options_;
   typedef std::map<std::string, boost::shared_ptr<MessageQueue> > buffers_t;
   buffers_t buffers_;

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -105,6 +105,9 @@ struct ROSBAG_DECL SnapshotterOptions
   bool clear_buffer_;
   // Compression type
   std::string compression_;
+  // Queue size for subscriptions
+  int queue_size_;
+
 
   typedef std::map<std::string, SnapshotterTopicOptions> topics_t;
   // Provides list of topics to snapshot and their limit configurations
@@ -202,8 +205,7 @@ public:
   int run();
 
 private:
-  // Subscribe queue size for each topic
-  static const int QUEUE_SIZE;
+  // Subscribe queue size for each topic 
   SnapshotterOptions options_;
   typedef std::map<std::string, boost::shared_ptr<MessageQueue> > buffers_t;
   buffers_t buffers_;

--- a/rosbag_snapshot/src/snapshot.cpp
+++ b/rosbag_snapshot/src/snapshot.cpp
@@ -134,7 +134,9 @@ bool parseVariablesMap(SnapshotterOptions& opts, po::variables_map const& vm)
   if (vm.count("queue-size"))
   {
     opts.queue_size_ = vm["queue-size"].as<int32_t>();
-  } else {
+  }
+  else
+  {
     opts.queue_size_ = 10;
   }
   return true;

--- a/rosbag_snapshot/src/snapshot.cpp
+++ b/rosbag_snapshot/src/snapshot.cpp
@@ -81,7 +81,9 @@ bool parseOptions(po::variables_map& vm, int argc, char** argv)
     ("topic", po::value<std::vector<std::string> >(),
      "Topic to buffer. If triggering write, write only these topics instead of all buffered topics.")
     ("compression,c", po::value<std::string>()->default_value("uncompressed"),
-     "Bag compression type. Default: uncompressed. Other options are: BZ2, LZ4.");
+     "Bag compression type. Default: uncompressed. Other options are: BZ2, LZ4.")
+    ("queue-size", po::value<int32_t>()->default_value(10),
+     "Queue size when subscribing to topics. Default: 10");
   // clang-format on
   po::positional_options_description p;
   p.add("topic", -1);
@@ -129,6 +131,12 @@ bool parseVariablesMap(SnapshotterOptions& opts, po::variables_map const& vm)
   else opts.clear_buffer_ = true;
   opts.all_topics_ = vm.count("all");
   opts.compression_ = vm["compression"].as<std::string>();
+  if (vm.count("queue-size"))
+  {
+    opts.queue_size_ = vm["queue-size"].as<int32_t>();
+  } else {
+    opts.queue_size_ = 10;
+  }
   return true;
 }
 
@@ -177,6 +185,8 @@ void appendParamOptions(ros::NodeHandle& nh, SnapshotterOptions& opts)
   // Set compression type
   const std::string default_compression{"uncompressed"};
   nh.param("compression", opts.compression_, default_compression);
+
+  nh.param("queue_size", opts.queue_size_, 10);
 
   if (!nh.getParam("topics", topics))
   {

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -242,8 +242,6 @@ MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const
   return range_t(begin, end);
 }
 
-const int Snapshotter::QUEUE_SIZE = 10;
-
 Snapshotter::Snapshotter(SnapshotterOptions const& options) : options_(options), recording_(true), writing_(false)
 {
   status_pub_ = nh_.advertise<rosbag_snapshot_msgs::SnapshotStatus>("snapshot_status", 10);
@@ -316,7 +314,7 @@ void Snapshotter::subscribe(string const& topic, boost::shared_ptr<MessageQueue>
   shared_ptr<ros::Subscriber> sub(boost::make_shared<ros::Subscriber>());
   ros::SubscribeOptions ops;
   ops.topic = topic;
-  ops.queue_size = QUEUE_SIZE;
+  ops.queue_size = options_.queue_size_;
   ops.md5sum = ros::message_traits::md5sum<topic_tools::ShapeShifter>();
   ops.datatype = ros::message_traits::datatype<topic_tools::ShapeShifter>();
   ops.helper =


### PR DESCRIPTION
Currently, the queue size when subscribing to topics is hardcoded to 10. This is not ideal for fast topics. 

I'm not sure if this is something you want, considering that ROS 1 is nearing end of life and so on. But I found this fix to be very useful for my own project. Feel free to merge it or ignore it :) 