### PR TITLE
cmake 4.0.0 support

### DIFF
--- a/rosbag_snapshot/CMakeLists.txt
+++ b/rosbag_snapshot/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 3.0.2)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.0.0)
+  cmake_minimum_required(VERSION 3.5)
+else()
+  cmake_minimum_required(VERSION 3.0.2)
+endif()
+
 project(rosbag_snapshot)
 
 find_package(catkin REQUIRED COMPONENTS rosbag rosbag_snapshot_msgs roscpp rosgraph_msgs std_srvs topic_tools)

--- a/rosbag_snapshot/CMakeLists.txt
+++ b/rosbag_snapshot/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.0.0)
   cmake_minimum_required(VERSION 3.5)
 else()
-  cmake_minimum_required(VERSION 3.0.2)
+  cmake_minimum_required(VERSION 3.13.4)
 endif()
 
 project(rosbag_snapshot)

--- a/rosbag_snapshot_msgs/CMakeLists.txt
+++ b/rosbag_snapshot_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.0.0)
   cmake_minimum_required(VERSION 3.5)
 else()
-  cmake_minimum_required(VERSION 3.0.2)
+  cmake_minimum_required(VERSION 3.13.4)
 endif()
 
 project(rosbag_snapshot_msgs)


### PR DESCRIPTION
## Description

- Fix #37 
- Yet maintain compatibility with legacy cmake versions

## How to test, use

### Install the latest cmake version (for Ubuntu)

As described here: https://apt.kitware.com/ .  
If a previous cmake version is installed, remove it first.

```bash
wget https://apt.kitware.com/kitware-archive.sh
chmod +x kitware-archive.sh
./kitware-archive.sh --release $(lsb_release -sc)
rm kitware-archive.sh
apt update
apt install -qqy cmake
```

expected result

```bash
cmake --version
```

```log
cmake version 4.0.0

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

And build the project as usual.