### PR TITLE
Bump Cmake min version to 3.13.4

### DIFF
--- a/rosbag_snapshot/CMakeLists.txt
+++ b/rosbag_snapshot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.13.4)
 project(rosbag_snapshot)
 
 find_package(catkin REQUIRED COMPONENTS rosbag rosbag_snapshot_msgs roscpp rosgraph_msgs std_srvs topic_tools)

--- a/rosbag_snapshot_msgs/CMakeLists.txt
+++ b/rosbag_snapshot_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.13.4)
 project(rosbag_snapshot_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation rosgraph_msgs)
@@ -9,4 +9,3 @@ generate_messages(DEPENDENCIES rosgraph_msgs)
 catkin_package(
     CATKIN_DEPENDS message_runtime rosgraph_msgs
 )
-


### PR DESCRIPTION
Possible solution to #37 

I picked 3.13.4 based on [the lowest CMake version listed in the Noetic target platforms](https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025), i.e. 3.13.4 for Debian Buster, rather than the 3.16.3 listed for Ubuntu Focal. Tip to @Timple 



